### PR TITLE
Only apply NO_NETWORK_POLICY to workload resources

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -500,6 +500,17 @@ def scanForMissingNetworkPolicy(path_script ):
         cnt = 0 
         dict_as_list = parser.loadMultiYAML( path_script )
         yaml_di      = parser.getSingleDict4MultiDocs( dict_as_list )        
+
+#Adjustment
+        WORKLOAD_KINDS = ['Pod', 'Deployment', 'StatefulSet', 'DaemonSet',
+                          'ReplicaSet', 'Job', 'CronJob']
+
+        kind = yaml_di.get('kind', '')
+
+        if kind not in WORKLOAD_KINDS:
+            return dic
+
+
         all_values = list( parser.getValuesRecursively(yaml_di)  )
         #print(all_values)
         #print(all_values)


### PR DESCRIPTION
The NO_NETWORK_POLICY rule is currently reported on every analyzed manifest, regardless of its resource type. Since a NetworkPolicy selects pods through its podSelector field, the rule is only meaningful for workload resources (Pod, Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, CronJob). Non-workload manifests such as Namespace, ConfigMap, Secret or Service cannot be associated with a NetworkPolicy, yet they still trigger the alert.
This change adds a check on the kind field before evaluating the rule.